### PR TITLE
Ignore auto-generated tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
When adding snipmate as a Pathogen bundle using git submodules, it is immediately turned dirty due to the tags file being generated inside the `doc` directory. If we gitignore it, we can keep our working directory clean.
