### PR TITLE
GPLv3 file header for Python

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -84,3 +84,22 @@ snippet ifmain
 # __magic__
 snippet _
 	__${1:init}__${2}
+# GPL
+snippet gpl
+	# ${1:Name}
+	# Copyright (C) `strftime("%Y")` ${2:Author}
+	#
+	# This program is free software: you can redistribute it and/or modify
+	# it under the terms of the GNU General Public License as published by
+	# the Free Software Foundation, either version 3 of the License, or
+	# (at your option) any later version.
+	#
+	# This program is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	# GNU General Public License for more details.
+	#
+	# You should have received a copy of the GNU General Public License
+	# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	
+	${3:#code}


### PR DESCRIPTION
Hey, 

I have add a snippet to the Python snippets file that I think a lot of people might benefit from. 

It inserts the GPLv3 file header, commented out, inserts the current year, and lets the user insert a name for the program and their name. Then it takes them to the end and they can start coding the program. 

No worries if you don't think this is suitable for your plugin. 

Thanks
