### PR TITLE
Enhanced Ruby do blocks

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -375,6 +375,10 @@ snippet seld
 snippet lam
 	lambda { |${1:args}| ${2} }
 snippet do
+	do${1}
+		${2}
+	end
+snippet doo
 	do |${1:variable}|
 		${2}
 	end


### PR DESCRIPTION
Not all Ruby 'do' blocks take a variable, so, let's provide the option.

I've remapped the existing 'do' block to "doo", which would result in the following:

<pre><code>do |cursor_is_here|
  
end</code></pre>


Whereas now "do" is maps to this snippet:

<pre><code>do#cursor is here
  # subsequent tab puts cursor here
end</code></pre>
