### PR TITLE
Feature/doc fix

### DIFF
--- a/doc/snipMate.txt
+++ b/doc/snipMate.txt
@@ -37,7 +37,7 @@ start typing once it's highlighted and all the matches specified in the
 snippet will be updated. To go in reverse, use <shift-tab>.
 
 ==============================================================================
-SYNTAX                                                        *snippet-syntax*
+SYNTAX                                                       *snipMate-syntax*
 
 Snippets can be defined in two ways. They can be in their own file, named
 after their trigger in 'snippets/<filetype>/<trigger>.snippet', or they can be


### PR DESCRIPTION
I fixed a typo in the docs -- the "snipMate-syntax" linking wasn't working, as the link at the SYNTAX heading read "snippets-syntax".
