### PR TITLE
Missing closing parenthesis for js timeout snippet

### DIFF
--- a/snippets/javascript.snippets
+++ b/snippets/javascript.snippets
@@ -65,7 +65,7 @@ snippet :f
 	}${3:,}
 # setTimeout function
 snippet timeout
-	setTimeout(function() {${3}}${2}, ${1:10};
+	setTimeout(function() {${3}}${2}, ${1:10});
 # Get Elements
 snippet get
 	getElementsBy${1:TagName}('${2}')${3}


### PR DESCRIPTION
Hi,

I've added missing closing parenthesis for js timeout snippet.

sickill
