### PR TITLE
Update snipmate's supertab handling for the latest supertab version.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 Quickly install with:
 
-    git clone git://github.com/msanders/snipmate.vim.git
+    git clone git://github.com/ervandew/snipmate.vim.git
 	cd snipmate.vim
 	cp -R * ~/.vim

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -149,9 +149,19 @@ endf
 fun! TriggerSnippet()
 	if exists('g:SuperTabMappingForward')
 		if g:SuperTabMappingForward == "<tab>"
-			let SuperTabKey = "\<c-n>"
+			let SuperTabPlug = maparg('<Plug>SuperTabForward', 'i')
+			if SuperTabPlug == ""
+				let SuperTabKey = "\<c-n>"
+			else
+				exec "let SuperTabKey = \"" . escape(SuperTabPlug, '<') . "\""
+			endif
 		elseif g:SuperTabMappingBackward == "<tab>"
-			let SuperTabKey = "\<c-p>"
+			let SuperTabPlug = maparg('<Plug>SuperTabBackward', 'i')
+			if SuperTabPlug == ""
+				let SuperTabKey = "\<c-p>"
+			else
+				exec "let SuperTabKey = \"" . escape(SuperTabPlug, '<') . "\""
+			endif
 		endif
 	endif
 

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -198,10 +198,20 @@ fun! BackwardsSnippet()
 	if exists('g:snipPos') | return snipMate#jumpTabStop(1) | endif
 
 	if exists('g:SuperTabMappingForward')
-		if g:SuperTabMappingBackward == "<s-tab>"
-			let SuperTabKey = "\<c-p>"
-		elseif g:SuperTabMappingForward == "<s-tab>"
-			let SuperTabKey = "\<c-n>"
+		if g:SuperTabMappingForward == "<s-tab>"
+			let SuperTabPlug = maparg('<Plug>SuperTabForward', 'i')
+			if SuperTabPlug == ""
+				let SuperTabKey = "\<c-n>"
+			else
+				exec "let SuperTabKey = \"" . escape(SuperTabPlug, '<') . "\""
+			endif
+		elseif g:SuperTabMappingBackward == "<s-tab>"
+			let SuperTabPlug = maparg('<Plug>SuperTabBackward', 'i')
+			if SuperTabPlug == ""
+				let SuperTabKey = "\<c-p>"
+			else
+				exec "let SuperTabKey = \"" . escape(SuperTabPlug, '<') . "\""
+			endif
 		endif
 	endif
 	if exists('SuperTabKey')


### PR DESCRIPTION
I made some changes to supertab to deal with users who have mapped <c-n>/<c-p> to something else and didn't want supertab clobbering those mappings.  So now supertab has a couple <Plug> mappings for forward/backward completion and some code to retain the user's original mappings. 

However, snipmate is still relying on <c-n>/<c-p> to kick off supertab, so I made a patch to utilize the new <Plug> mappings when available (should retain backwards compatibility with older supertab versions), which resolves any issues I've encountered with supertab + snipmate + user mapped <c-n>/<c-p>.

Let me know if you have any questions regarding these changes.

Thanks!
