### PR TITLE
remove doc/tags from git status listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
doc/tags is generated upon first usage and will make git status complaign
when snipmate is used as a submodule

Commit message says everything. When using the pathogen plugin and vim this will keep git status from complaining about untracked content
