### PR TITLE
Change perl start to use env like python and ruby

### DIFF
--- a/snippets/perl.snippets
+++ b/snippets/perl.snippets
@@ -1,6 +1,6 @@
 # #!/usr/bin/perl
 snippet #!
-	#!/usr/bin/perl
+	#!/usr/bin/env perl
 
 # Hash Pointer
 snippet .


### PR DESCRIPTION
For perl #! autocompletes to 

```
#!/usr/bin/perl
```

Like the python and ruby snippets, this might be better done as

```
#!/usr/bin/env perl
```
