### PR TITLE
Minor PHP Snippet Suggestions

### DIFF
--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -43,7 +43,7 @@ snippet doc_cp
 	 *
 	 * @package ${2:default}
 	 * @author ${3:`g:snips_author`}
-	**/${4}
+	 **/${4}
 # Class Variable - post doc
 snippet doc_vp
 	/**
@@ -64,7 +64,7 @@ snippet doc_c
 	/**
 	 * ${3:undocumented class}
 	 *
-	 * @packaged ${4:default}
+	 * @package ${4:default}
 	 * @author ${5:`g:snips_author`}
 	 **/
 	${1:}class ${2:}

--- a/snippets/php.snippets
+++ b/snippets/php.snippets
@@ -35,7 +35,7 @@ snippet $_ SESSION['...']
 snippet /*
 	/**
 	 * ${1}
-	 **/
+	 */
 # Class - post doc
 snippet doc_cp
 	/**
@@ -43,21 +43,21 @@ snippet doc_cp
 	 *
 	 * @package ${2:default}
 	 * @author ${3:`g:snips_author`}
-	 **/${4}
+	 */${4}
 # Class Variable - post doc
 snippet doc_vp
 	/**
 	 * ${1:undocumented class variable}
 	 *
 	 * @var ${2:string}
-	 **/${3}
+	 */${3}
 # Class Variable
 snippet doc_v
 	/**
 	 * ${3:undocumented class variable}
 	 *
 	 * @var ${4:string}
-	 **/
+	 */
 	${1:var} $${2};${5}
 # Class
 snippet doc_c
@@ -66,7 +66,7 @@ snippet doc_c
 	 *
 	 * @package ${4:default}
 	 * @author ${5:`g:snips_author`}
-	 **/
+	 */
 	${1:}class ${2:}
 	{${6}
 	} // END $1class $2
@@ -74,12 +74,12 @@ snippet doc_c
 snippet doc_dp
 	/**
 	 * ${1:undocumented constant}
-	 **/${2}
+	 */${2}
 # Constant Definition
 snippet doc_d
 	/**
 	 * ${3:undocumented constant}
-	 **/
+	 */
 	define(${1}, ${2});${4}
 # Function - post doc
 snippet doc_fp
@@ -88,7 +88,7 @@ snippet doc_fp
 	 *
 	 * @return ${2:void}
 	 * @author ${3:`g:snips_author`}
-	 **/${4}
+	 */${4}
 # Function signature
 snippet doc_s
 	/**
@@ -96,7 +96,7 @@ snippet doc_s
 	 *
 	 * @return ${5:void}
 	 * @author ${6:`g:snips_author`}
-	 **/
+	 */
 	${1}function ${2}(${3});${7}
 # Function
 snippet doc_f
@@ -105,7 +105,7 @@ snippet doc_f
 	 *
 	 * @return ${5:void}
 	 * @author ${6:`g:snips_author`}
-	 **/
+	 */
 	${1}function ${2}(${3})
 	{${7}
 	}
@@ -118,11 +118,11 @@ snippet doc_h
 	 * @version ${3:$Id$}
 	 * @copyright ${4:$2}, `strftime('%d %B, %Y')`
 	 * @package ${5:default}
-	 **/
+	 */
 	
 	/**
 	 * Define DocBlock
-	 *//
+	 */
 # Interface
 snippet doc_i
 	/**
@@ -130,7 +130,7 @@ snippet doc_i
 	 *
 	 * @package ${3:default}
 	 * @author ${4:`g:snips_author`}
-	 **/
+	 */
 	interface ${1:}
 	{${5}
 	} // END interface $1
@@ -138,7 +138,7 @@ snippet doc_i
 snippet class
 	/**
 	 * ${1}
-	 **/
+	 */
 	class ${2:ClassName}
 	{
 		${3}


### PR DESCRIPTION
This is my first pull request so if I did something wrong please let me know. phpdoc is almost the standard automatic docblock parser (not official but basically what everyone uses) for php. It shows the ending of all docblocks to be _/ instead of *_/. So I changed this in the snippets.

I also noticed one snippet which was missing a space that would cause my vim to go crazy and freeze/lag when I tried to use some snippets. The space wasn't missing in the /\* snippet but it seemed to still cause vim to freeze up when I used that snippet.

I also noticed that one docblock had @packaged which isn't a valid docblock tag that I've seen so I changed it to @package.
