### PR TITLE
there are no semicolons after the closing curly bracket from `for` on ja...

### DIFF
--- a/snippets/javascript.snippets
+++ b/snippets/javascript.snippets
@@ -42,12 +42,12 @@ snippet case
 snippet for
 	for (var ${2:i} = 0; $2 < ${1:Things}.length; $2${3:++}) {
 		${4:$1[$2]}
-	};
+	}
 # for (...) {...} (Improved Native For-Loop)
 snippet forr
 	for (var ${2:i} = ${1:Things}.length - 1; $2 >= 0; $2${3:--}) {
 		${4:$1[$2]}
-	};
+	}
 # while (...) {...}
 snippet wh
 	while (${1:/* condition */}) {


### PR DESCRIPTION
...vascript