### PR TITLE
simple class definition snippet added

### DIFF
--- a/snippets/python.snippets
+++ b/snippets/python.snippets
@@ -24,6 +24,10 @@ snippet cl
 			${5:super($1, self).__init__()}
 			self.$4 = $4
 			${6}
+# Simple New Class
+snippet cls
+	class ${1:ClassName}(${2:object}):
+		${3:pass}
 # New Function
 snippet def
 	def ${1:fname}(${2:`indent('.') ? 'self' : ''`}):


### PR DESCRIPTION
I added a Simple Class Definition snippet in python snippet.
Because I think this way will be widely used:
<example>
cls<tab>
    defs<tab>
</example>

the default class definition snippe cl will generate a **init** method, which is not always useful.
