### PR TITLE
Ignore doc/tags* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags*


### PR DESCRIPTION
In order to work with pathogen we need to ignore doc/tags\* files.

Signed-off-by: Matěj Cepl mcepl@redhat.com
