### PR TITLE
Add .gitignore to prevent doc tags being tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
If one uses a git repository to track their dotfiles and the snipmate
repository is set up as a submodule, git complains that the snipmate
repository has been modified when you generate vim doc tags.
