### PR TITLE
Less destructive plugin compatibility

### DIFF
--- a/after/plugin/snipMate.vim
+++ b/after/plugin/snipMate.vim
@@ -10,24 +10,26 @@ let s:did_snips_mappings = 1
 "
 " You can safely adjust these mappings to your preferences (as explained in
 " :help snipMate-remap).
-ino <silent> <tab> <c-r>=TriggerSnippet()<cr>
-snor <silent> <tab> <esc>i<right><c-r>=TriggerSnippet()<cr>
-ino <silent> <s-tab> <c-r>=BackwardsSnippet()<cr>
-snor <silent> <s-tab> <esc>i<right><c-r>=BackwardsSnippet()<cr>
-ino <silent> <c-r><tab> <c-r>=ShowAvailableSnips()<cr>
+if exists('SuperTabKey')
+	ino <silent> <tab> <c-r>=TriggerSnippet()<cr>
+	snor <silent> <tab> <esc>i<right><c-r>=TriggerSnippet()<cr>
+	ino <silent> <s-tab> <c-r>=BackwardsSnippet()<cr>
+	snor <silent> <s-tab> <esc>i<right><c-r>=BackwardsSnippet()<cr>
+	ino <silent> <c-r><tab> <c-r>=ShowAvailableSnips()<cr>
 
-" The default mappings for these are annoying & sometimes break snipMate.
-" You can change them back if you want, I've put them here for convenience.
-snor <bs> b<bs>
-snor <right> <esc>a
-snor <left> <esc>bi
-snor ' b<bs>'
-snor ` b<bs>`
-snor % b<bs>%
-snor U b<bs>U
-snor ^ b<bs>^
-snor \ b<bs>\
-snor <c-x> b<bs><c-x>
+	" The default mappings for these are annoying & sometimes break snipMate.
+	" You can change them back if you want, I've put them here for convenience.
+	snor <bs> b<bs>
+	snor <right> <esc>a
+	snor <left> <esc>bi
+	snor ' b<bs>'
+	snor ` b<bs>`
+	snor % b<bs>%
+	snor U b<bs>U
+	snor ^ b<bs>^
+	snor \ b<bs>\
+	snor <c-x> b<bs><c-x>
+endif
 
 " By default load snippets in snippets_dir
 if empty(snippets_dir)

--- a/doc/snipMate.txt
+++ b/doc/snipMate.txt
@@ -185,6 +185,10 @@ directory, or use the |ExtractSnips()|function. This will be used by the
 |globpath()| function, and so accepts the same syntax as it (e.g.,
 comma-separated paths).
 
+CanExpandSnippet()                                      *CanExpandSnippet()*
+CanExpandSnippet() Returns 0 (False) or 1 (True) to test if snipMate will
+expand the snippet under the current cursor position.
+
 ExtractSnipsFile({directory}, {filetype})     *ExtractSnipsFile()* *.snippets*
 
 ExtractSnipsFile() extracts the specified *.snippets file for the given

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -18,6 +18,22 @@ if !exists('snips_author') | let snips_author = 'Me' | endif
 au BufRead,BufNewFile *.snippets\= set ft=snippet
 au FileType snippet setl noet fdm=indent
 
+ino <silent> <tab> <c-r>=TriggerSnippet()<cr>
+snor <silent> <tab> <esc>i<right><c-r>=TriggerSnippet()<cr>
+ino <silent> <s-tab> <c-r>=BackwardsSnippet()<cr>
+snor <silent> <s-tab> <esc>i<right><c-r>=BackwardsSnippet()<cr>
+ino <silent> <c-r><tab> <c-r>=ShowAvailableSnips()<cr>
+snor <bs> b<bs>
+snor <right> <esc>a
+snor <left> <esc>bi
+snor ' b<bs>'
+snor ` b<bs>`
+snor % b<bs>%
+snor U b<bs>U
+snor ^ b<bs>^
+snor \ b<bs>\
+snor <c-x> b<bs><c-x>
+
 let s:snippets = {} | let s:multi_snips = {}
 
 if !exists('snippets_dir')

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -184,6 +184,21 @@ fun! TriggerSnippet()
 	return "\<tab>"
 endf
 
+fun! CanExpandSnippet()
+	if exists('g:snipPos') | return snipMate#jumpTabStop(0) | endif
+
+	let word = matchstr(getline('.'), '\S\+\%'.col('.').'c')
+	for scope in [bufnr('%')] + split(&ft, '\.') + ['_']
+		let [trigger, snippet] = s:GetSnippet(word, scope)
+		" If word is a trigger for a snippet, delete the trigger & expand
+		" the snippet.
+		if snippet != ''
+			return 1
+		endif
+	endfor
+	return 0
+endf
+
 fun! BackwardsSnippet()
 	if exists('g:snipPos') | return snipMate#jumpTabStop(1) | endif
 


### PR DESCRIPTION
Mappings in the after directory are setup to only apply when snipMate detects supertab instead of all the time.

Also added in a helper function that will test if snipMate will expand a snippet or not.
