### PR TITLE
Enforcing sun code conventions with respect to curly brackets.

### DIFF
--- a/snippets/java.snippets
+++ b/snippets/java.snippets
@@ -1,7 +1,6 @@
 snippet main
-	public static void main (String [] args)
-	{
-		${1:/* code */}
+	public static void main(String[] args) {
+		${1}
 	}
 snippet pu
 	public
@@ -45,19 +44,33 @@ snippet j.n
 snippet j.m
 	java.math.
 snippet if
-	if (${1}) ${2}
+	if (${1}) {
+		${2}
+	}${3}
 snippet el
-	else 
+	else {
+		${1}
+	}${2}
 snippet elif
-	else if (${1}) ${2}
+	else if (${1}) {
+		${2}
+	}${3}
 snippet wh
-	while (${1}) ${2}
+	while (${1}) {
+		${2}
+	}
 snippet for
-	for (${1}; ${2}; ${3}) ${4}
+	for (${1}; ${2}; ${3}) {
+		${4}
+	}
 snippet fore
-	for (${1} : ${2}) ${3}
+	for (${1} : ${2}) {
+		${3}
+	}
 snippet sw
-	switch (${1}) ${2}
+	switch (${1}) {
+		${2}
+	}
 snippet cs
 	case ${1}:
 		${2}
@@ -71,7 +84,9 @@ snippet cl
 snippet in
 	interface ${1:`Filename("", "untitled")`} ${2:extends Parent}${3}
 snippet m
-	${1:void} ${2:method}(${3}) ${4:throws }${5}
+	${1:void} ${2:method}(${3}) ${4:throws }{
+		${5}
+	}
 snippet v
 	${1:String} ${2:var}${3: = null}${4};${5}
 snippet co


### PR DESCRIPTION
Curly brackets should enclose single clauses by default, and method names and array type names shouldn't contain spaces.
