### PR TITLE
Update for snippet with normal for syntax

### DIFF
--- a/doc/snipMate.txt
+++ b/doc/snipMate.txt
@@ -94,7 +94,7 @@ the tab stop. This text then can be copied throughout the snippet using "$#",
 given # is the same number as used before. So, to make a C for loop: >
 
  snippet for
- 	for (${2:i}; $2 < ${1:count}; $1++) {
+ 	for (${2:i}; $2 < ${1:count}; $2++) {
 		${4}
 	}
 


### PR DESCRIPTION
With the current example snippet the for loop would look like
for(i; i < count; count++)
This would be incrementing the control. I thought that the documentation should create the following instead:
for(i; i < count; i++)

I believe this is more of a realistic scenario.

Amos King @adkron amos.l.king@gmail.com
