### PR TITLE
Added support for custom mappings.

### DIFF
--- a/after/plugin/snipMate.vim
+++ b/after/plugin/snipMate.vim
@@ -10,11 +10,24 @@ let s:did_snips_mappings = 1
 "
 " You can safely adjust these mappings to your preferences (as explained in
 " :help snipMate-remap).
-ino <silent> <tab> <c-r>=TriggerSnippet()<cr>
-snor <silent> <tab> <esc>i<right><c-r>=TriggerSnippet()<cr>
-ino <silent> <s-tab> <c-r>=BackwardsSnippet()<cr>
-snor <silent> <s-tab> <esc>i<right><c-r>=BackwardsSnippet()<cr>
-ino <silent> <c-r><tab> <c-r>=ShowAvailableSnips()<cr>
+if !exists("g:snipMateTriggerSnippetKey")
+    let g:snipMateTriggerSnippetKey = "<tab>"
+endif
+
+if !exists("g:snipMateBackwardSnippetKey")
+    let g:snipMateBackwardSnippetKey = "<s-tab>"
+endif
+
+if !exists("g:snipMateShowAvailableSnipsKey")
+    let g:snipMateShowAvailableSnipsKey = "<c-r><tab>"
+endif
+
+
+exe "ino <silent> ".g:snipMateTriggerSnippetKey." <c-r>=TriggerSnippet()<cr>"
+exe "snor <silent> ".g:snipMateTriggerSnippetKey." <esc>i<right><c-r>=TriggerSnippet()<cr>"
+exe "ino <silent> ".g:snipMateBackwardSnippetKey." <c-r>=BackwardsSnippet()<cr>"
+exe "snor <silent> ".g:snipMateBackwardSnippetKey." <esc>i<right><c-r>=BackwardsSnippet()<cr>"
+exe "ino <silent> ".g:snipMateShowAvailableSnipsKey." <c-r>=ShowAvailableSnips()<cr>"
 
 " The default mappings for these are annoying & sometimes break snipMate.
 " You can change them back if you want, I've put them here for convenience.

--- a/doc/snipMate.txt
+++ b/doc/snipMate.txt
@@ -234,17 +234,18 @@ just enable 'expandtab' and set 'softtabstop' to your preferred amount of
 spaces. If 'softtabstop' is not set, 'shiftwidth' is used instead.
 
                                                               *snipMate-remap*
-snipMate does not come with a setting to customize the trigger key, but you
-can remap it easily in the two lines it's defined in the 'after' directory
-under 'plugin/snipMate.vim'. For instance, to change the trigger key
-to CTRL-J, just change this: >
+snipMate comes with a setting to customize the trigger key. You
+can remap it easily in your config by setting a corresponding variable. For
+instance, to have CTRL-J to trigger snippets add the following line to your
+config:
 
- ino <tab> <c-r>=TriggerSnippet()<cr>
- snor <tab> <esc>i<right><c-r>=TriggerSnippet()<cr>
+ let g:snipMateTriggerSnippetKey = "<c-j>"
 
-to this: >
- ino <c-j> <c-r>=TriggerSnippet()<cr>
- snor <c-j> <esc>i<right><c-r>=TriggerSnippet()<cr>
+Default mappings are:
+
+ g:snipMateTriggerSnippetKey = "<tab>"
+ g:snipMateBackwardSnippetKey = "<s-tab>"
+ g:snipMateShowAvailableSnipsKey = "<c-r><tab>"
 
 ==============================================================================
 FEATURES                                                   *snipMate-features*


### PR DESCRIPTION
This minor change allows users to override default mappings to any custom shortcut they want without a need to modify snipmate's original source and/or cloning the plugin. Having to modify `after/plugin/snipMate.vim` is very inconvenient as it requires an extra effort when setting up the environment and updating plugins.
