### PR TITLE
Add g:snipmate_default_choice option

### DIFF
--- a/doc/snipMate.txt
+++ b/doc/snipMate.txt
@@ -221,12 +221,19 @@ in the current buffer to show a list via |popupmenu-completion|.
 ==============================================================================
 SETTINGS                                  *snipMate-settings* *g:snips_author*
 
-The g:snips_author string (similar to $TM_FULLNAME in TextMate) should be set
+The `g:snips_author string (similar to $TM_FULLNAME in TextMate) should be set
 to your name; it can then be used in snippets to automatically add it. E.g.: >
 
  let g:snips_author = 'Hubert Farnsworth'
  snippet name
  	`g:snips_author`
+<
+                                                 *g:snipmate_default_choice*
+
+The `g:snipmate_default_choice` variable is provided to select in advance an
+option when snipmate output several alternatives, by default it selects none >
+
+ let g:snipmate_default_choice = 1
 <
                                      *snipMate-expandtab* *snipMate-indenting*
 If you would like your snippets to be expanded using spaces instead of tabs,

--- a/plugin/snipMate.vim
+++ b/plugin/snipMate.vim
@@ -223,14 +223,18 @@ fun s:GetSnippet(word, scope)
 endf
 
 fun s:ChooseSnippet(scope, trigger)
-	let snippet = []
+	if !exists('g:snipmate_default_choice') | let snippet = [] | else | let snippet = "" | endif
 	let i = 1
 	for snip in s:multi_snips[a:scope][a:trigger]
-		let snippet += [i.'. '.snip[0]]
+		if !exists('g:snipmate_default_choice') | let snippet += [i.'. '.snip[0]] | else | let snippet .= i.'. '.snip[0] . "\n" | endif
 		let i += 1
 	endfor
 	if i == 2 | return s:multi_snips[a:scope][a:trigger][0][1] | endif
-	let num = inputlist(snippet) - 1
+	if !exists('g:snipmate_default_choice') | let num = inputlist(snippet) - 1
+	else
+		let snippet .= 'Type number and <Enter> or press <Esc> to cancel: '
+		let num = str2nr(input(snippet, g:snipmate_default_choice)) - 1
+	endif
 	return num == -1 ? '' : s:multi_snips[a:scope][a:trigger][num][1]
 endf
 


### PR DESCRIPTION
When several snippets match a trigger in snipmate an input dialog is displayed asking for an option, the default behavour is to force the user to input a number and cancel the operation if none is selected, I prefer to press `<Enter>` to select the 1st option and only input a number when I decide to use another snippet or press `<Esc>` to cancel the operation.

This pull request adds a `g:snipmate_default_option` variable who accepts numerical values to pre-select an option on those cases, eg.

```
let g:snipmage_default_option = 1
```
